### PR TITLE
fix typo: defalut => default at config_param :threshold

### DIFF
--- a/lib/fluent/plugin/out_grepcount_filter.rb
+++ b/lib/fluent/plugin/out_grepcount_filter.rb
@@ -8,7 +8,7 @@ module Fluent
     (1..REGEXP_MAX_NUM).each {|i| config_param :"exclude#{i}", :string, :default => 1}
     config_param :count_interval, :time, :default => 60,
                  :desc => 'The interval time to count in seconds.'
-    config_param :threshold, :integer, :defalut => 1
+    config_param :threshold, :integer, :default => 1
     config_param :output_setting, :bool, :default => false
 
     attr_accessor :interval


### PR DESCRIPTION
is this typo?  
in L11, `defalut` => `default`
```
config_param :threshold, :integer, :defalut => 1
```

When using fluentd 1.11.0 and ruby 2.6.3, launching fluentd gives an error and can't launch fluentd.
```
raceback (most recent call last):
        33: from /usr/local/rbenv/versions/2.6.3/bin/fluentd:23:in `<main>'
        32: from /usr/local/rbenv/versions/2.6.3/bin/fluentd:23:in `load'
        31: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/bin/fluentd:8:in `<top (required)>'
        30: from /usr/local/rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        29: from /usr/local/rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        28: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/command/fluentd.rb:330:in `<top (required)>'
        27: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/supervisor.rb:551:in `run_supervisor'
        26: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/engine.rb:80:in `run_configure'
        25: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/engine.rb:105:in `configure'
        24: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/root_agent.rb:143:in `configure'
        23: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/root_agent.rb:143:in `each'
        22: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/root_agent.rb:143:in `block in configure'
        21: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/label.rb:31:in `configure'
        20: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/agent.rb:64:in `configure'
        19: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/agent.rb:64:in `each'
        18: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/agent.rb:74:in `block in configure'
        17: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/agent.rb:130:in `add_match'
        16: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/plugin.rb:109:in `new_output'
        15: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/plugin.rb:155:in `new_impl'
        14: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/registry.rb:44:in `lookup'
        13: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/registry.rb:99:in `search'
        12: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/registry.rb:99:in `each'
        11: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/registry.rb:102:in `block in search'
        10: from /usr/local/rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
         9: from /usr/local/rbenv/versions/2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
         8: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluent-plugin-grepcount-filter-0.0.1/lib/fluent/plugin/out_grepcount_filter.rb:1:in `<top (required)>'
         7: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluent-plugin-grepcount-filter-0.0.1/lib/fluent/plugin/out_grepcount_filter.rb:2:in `<module:Fluent>'
         6: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluent-plugin-grepcount-filter-0.0.1/lib/fluent/plugin/out_grepcount_filter.rb:11:in `<class:GrepCountFilterOutput>'
         5: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/configurable.rb:158:in `config_param'
         4: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/config/configure_proxy.rb:318:in `config_param'
         3: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/config/configure_proxy.rb:250:in `parameter_configuration'
         2: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/config/configure_proxy.rb:233:in `config_parameter_option_validate!'
         1: from /usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/config/configure_proxy.rb:233:in `each_key'
/usr/local/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/fluentd-1.11.0/lib/fluent/config/configure_proxy.rb:244:in `block in config_parameter_option_validate!': unknown option 'defalut' for configuration parameter: threshold (ArgumentError)
```
